### PR TITLE
Fix system build prop rename

### DIFF
--- a/start
+++ b/start
@@ -270,7 +270,7 @@ clone_repo() {
     if [ -f "system/build.prop" ]; then
       mv system/build.prop ./build.prop
     elif [ -f "system/system/build.prop" ]; then
-      mv system/system/build.prop ./system-build.prop
+      mv system/system/build.prop ./build.prop
     fi
 
     if [ -f "system/vendor/build.prop" ]; then


### PR DESCRIPTION
When the system build prop file is found in the nested `system/system` folder the file was renamed to "system-build.prop", letting the pif generator fail due to it looking only for "build.prop".